### PR TITLE
chore: add Renovate config for GitHub Actions and site npm deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits"
+  ],
+  "timezone": "Europe/Berlin",
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 2,
+  "labels": ["dependencies"],
+  "ignorePaths": [
+    "**/node_modules/**",
+    ".build/**",
+    "build/**"
+  ],
+  "packageRules": [
+    {
+      "description": "Group all GitHub Actions bumps into one PR — they are low-risk and land together.",
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions",
+      "automerge": false
+    },
+    {
+      "description": "TypeScript is a build-only dep for the landing page; minor/patch bumps can ride together.",
+      "matchFileNames": ["site/package.json"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "site devDependencies"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "schedule": ["at any time"]
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on the first day of the month"]
+  }
+}


### PR DESCRIPTION
Adds `renovate.json` so Renovate keeps our GitHub Actions and the landing-page npm deps current.

## What it covers

Verified with a local dry run (`renovate --platform=local --dry-run=lookup`), which detected 4 package files / 17 deps:

- **github-actions** — 3 workflow files, 16 deps (the 5 `actions/*` uses, runner images, and the `node-version: "20"` pin in `pages.yml`)
- **npm** — `site/package.json` (`typescript`)

`Package.swift` has no external dependencies, so there is nothing for Renovate to do there. Vendored `site/node_modules` is excluded and was correctly skipped in the dry run.

## Config choices

- Weekly schedule, Monday before 6am (Europe/Berlin), max 3 concurrent PRs
- All GitHub Actions bumps grouped into a single PR
- Semantic commits (`chore(deps): ...`), matching existing commit style
- Dependency dashboard issue for visibility
- Security alerts bypass the schedule so they land immediately
- Monthly lockfile maintenance for `site/package-lock.json`

Config validates cleanly against `renovate-config-validator`.

## Follow-up

The bot does not start until the Mend Renovate app is installed on this repo (free for public repos): https://github.com/apps/renovate

Since `renovate.json` already exists, Renovate skips the onboarding PR and opens the Dependency Dashboard issue on its first run.