### PR TITLE
chore: automerge non-major Renovate PRs once CI is green

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":dependencyDashboard",
     ":semanticCommits"
   ],
+  "dependencyDashboard": false,
   "timezone": "Europe/Berlin",
   "schedule": ["before 6am on monday"],
   "prConcurrentLimit": 3,

--- a/renovate.json
+++ b/renovate.json
@@ -15,19 +15,29 @@
     ".build/**",
     "build/**"
   ],
+  "automergeStrategy": "squash",
+  "platformAutomerge": false,
   "packageRules": [
     {
-      "description": "Group all GitHub Actions bumps into one PR — they are low-risk and land together.",
+      "description": "Actions minor/patch/digest are exercised directly by CI — let them land unattended once it is green.",
       "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "groupName": "github actions",
-      "automerge": false
+      "automerge": true
     },
     {
-      "description": "TypeScript is a build-only dep for the landing page; minor/patch bumps can ride together.",
+      "description": "Landing-page build deps: minor/patch only, grouped.",
       "matchFileNames": ["site/package.json"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "site devDependencies"
+      "groupName": "site devDependencies",
+      "automerge": true
+    },
+    {
+      "description": "Majors change behaviour in ways green CI does not always catch (runner images, compiler rewrites). Always review by hand.",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "addLabels": ["needs-review"]
     }
   ],
   "vulnerabilityAlerts": {
@@ -36,6 +46,7 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 6am on the first day of the month"]
+    "schedule": ["before 6am on the first day of the month"],
+    "automerge": true
   }
 }


### PR DESCRIPTION
Enables automerge so routine dependency bumps land without manual clicks. Renovate still waits for CI to pass before merging — `ignoreTests` stays at its default, so a red build blocks the merge.

## What automerges

| Update | Automerge | Why |
|---|---|---|
| Actions minor/patch/digest | yes | CI runs these actions directly, so green CI is real evidence |
| `site/` devDeps minor/patch | yes | Build-only, not shipped to users |
| Monthly lockfile maintenance | yes | Transitive-only, no manifest change |
| **Any major** | **no** | Labelled `needs-review` |

## Why majors stay manual

The two majors that just landed make the case: `macos-15` → `macos-26` (whole runner image) and TypeScript `5` → `7` (compiler rewrite). Both passed CI, but both are changes worth a human glance before they're in `main`.

## Mechanism

`platformAutomerge: false` — `main` has no branch protection and the repo has *Allow auto-merge* disabled, so GitHub's native auto-merge isn't available. Renovate polls and merges via API once checks are green. `automergeStrategy: "squash"` keeps one commit per bump.

Validated with `renovate-config-validator`.

## Note

CI does not currently compile the site's TypeScript — `pages.yml` uploads `site/` as-is, including the committed `main.js`. So green CI is not evidence that a `typescript` bump is safe. Low stakes while `main.js` is prebuilt and committed, but worth knowing before that changes.