### PR TITLE
fix: site build was broken by TypeScript 7, and CI never caught it

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,51 @@
+name: Site
+
+# The landing page ships as a prebuilt artifact: pages.yml uploads site/ as-is,
+# including the committed main.js. Nothing else in CI compiles the TypeScript,
+# so without this workflow a broken tsc or a stale main.js reaches production
+# unnoticed — which is how the TypeScript 7 bump landed green.
+on:
+  push:
+    branches: [main]
+    paths: [site/**, .github/workflows/site.yml]
+  pull_request:
+    branches: [main]
+    paths: [site/**, .github/workflows/site.yml]
+
+concurrency:
+  group: site-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Compile TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install
+        working-directory: site
+        run: npm ci
+
+      - name: Compile
+        working-directory: site
+        run: npm run build
+
+      # main.js is committed and is what actually gets deployed, so it has to
+      # match what src/main.ts compiles to. Skips itself if main.js stops being
+      # tracked, i.e. once it is built during deploy instead of committed.
+      - name: Committed main.js is up to date
+        run: |
+          if git ls-files --error-unmatch site/main.js >/dev/null 2>&1; then
+            if ! git diff --exit-code -- site/main.js; then
+              echo "::error::site/main.js is stale. Run 'npm run build' in site/ and commit the result."
+              exit 1
+            fi
+          else
+            echo "site/main.js is not tracked — built at deploy time, nothing to verify."
+          fi

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -2,12 +2,13 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020", "DOM"],
-    "module": "None",
-    "outFile": "main.js",
+    "rootDir": "src",
+    "outDir": ".",
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true
   },
-  "include": ["src/main.ts"]
+  "include": ["src/main.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## The bug

`npm run build` has been failing on `main` since the `typescript` v7 bump merged:

```
tsconfig.json(5,15): error TS6046: Argument for '--module' option must be: ...
tsconfig.json(6,5):  error TS5102: Option 'outFile' has been removed.
```

TypeScript 7 removed `outFile` and dropped the `"module": "None"` value.

## Why it went unnoticed

Nothing in CI compiles the landing page. `pages.yml` uploads `site/` as-is, including the committed `main.js`, so the dependency bump had no way to fail. The live site is currently fine *only* because that prebuilt artifact predates the bump.

This would have become visible the moment `main.js` stopped being committed and started being built during deploy.

## The fix

`rootDir` + `outDir` in place of `outFile`, and drop the removed `module` setting. Since `src/main.ts` has no imports or exports, tsc still treats it as a script and still emits `"use strict"`.

Verified byte-identical to the committed artifact:

```
committed sha256: 55ff12964767de7a73e53225696da201d2ec4d69448d392575e850393fe69562
rebuilt   sha256: 55ff12964767de7a73e53225696da201d2ec4d69448d392575e850393fe69562
```

Deleting `main.js` and rebuilding from scratch reproduces it exactly, and emits no other files. **No shipped JavaScript changes.**

## The coverage

New `Site` workflow: install, compile, then verify the committed `main.js` matches `src/main.ts`. That last check matters because the committed artifact is what actually deploys — a stale `main.js` is a silently wrong production site.

The check skips itself if `main.js` stops being tracked, so it stays correct if the build moves into the deploy step.

Deliberately a separate workflow rather than a job in `ci.yml`, to avoid conflicting with in-flight local changes to that file.